### PR TITLE
Use full async capabilities of the tapable library.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,10 +17,6 @@ class FractalWebpackPlugin {
         if (this.options.configPath) {
             fractal = require(path.join(process.cwd(), this.options.configPath));
         }
-
-        this.hooks = {
-          done: new AsyncSeriesHook(['compilation', 'callback'])
-        }
     }
 
     apply(compiler) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const { AsyncSeriesHook } = require('tapable');
 
 try {
     var fractal = require(path.join(process.cwd(), 'fractal'));

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ class FractalWebpackPlugin {
         }
 
         this.hooks = {
-          shouldEmit: new AsyncSeriesHook(['compilation', 'callback'])
+          done: new AsyncSeriesHook(['compilation', 'callback'])
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fractal-webpack-plugin",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Fractal webpack plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Both fractal commands ("startServer", "build") return promises, but the hook is using a synchronous tap. Modify the hook to use `tapAsync` instead.

This change enables fractal-webpack-plugin to be chained with other plugins that require the fractal build to complete before performing work.