### PR TITLE
Make sure webpack's compilation callback is called

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,8 @@ class FractalWebpackPlugin {
                 });
             } else if (this.options.mode === 'build') {
                 this.build().then(callback);
+            } else {
+                callback();
             }
         });
     }


### PR DESCRIPTION
With `webpack@^5.74.0"`
When using `webpack --watch` it gets stuck (after the first handled file change event) if the `callback` is not invoked properly.

*Side note:* With `webpack@^4.42.1` the issue doesn't exist. so it's like an issue when upgrading to Webpack 5.